### PR TITLE
Patch the way actions are run and how they are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.4 2021-03-04
+
+- Fix bug in code and allow setting action from json by converting to symbol
+
 ## 4.0.3 2021-03-02
 
 - Releasing fork with ability to set action

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ allow_any_instance_of(Chef::Recipe).to receive(:chrome_version).and_return('50.0
 
 - `node['chrome']['track']` - For Linux only. Install stable, beta or unstable version. Default is `stable`.
 - `node['chrome']['32bit_only']` - For windows only. Install 32-bit browser on 64-bit machines. Default is `false`.
-- `node['chrome']['action']` - The action to use when configuring the package. Default is `:install`.
+- `node['chrome']['action']` - The action to use when configuring the package. Default is `install`.
 
 See [attributes/default.rb](https://github.com/dhoer/chef-chrome/blob/master/attributes/default.rb) for complete list 
 of attributes.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,4 +20,4 @@ default['chrome']['msi'] = 'https://dl-ssl.google.com/tag/s/appguid=%7B8A69D345-
 default['chrome']['yum_baseurl'] = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
 default['chrome']['yum_gpgkey'] = 'https://dl-ssl.google.com/linux/linux_signing_key.pub'
 
-default['chrome']['action'] = :install
+default['chrome']['action'] = install

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,4 +20,4 @@ default['chrome']['msi'] = 'https://dl-ssl.google.com/tag/s/appguid=%7B8A69D345-
 default['chrome']['yum_baseurl'] = 'http://dl.google.com/linux/chrome/rpm/stable/$basearch'
 default['chrome']['yum_gpgkey'] = 'https://dl-ssl.google.com/linux/linux_signing_key.pub'
 
-default['chrome']['action'] = install
+default['chrome']['action'] = "install"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ description 'Installs/Configures Chrome browser'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/dhoer/chef-chrome'
 issues_url 'https://github.com/dhoer/chef-chrome/issues'
-version '4.0.3'
+version '4.0.4'
 
-chef_version '>= 12.14'
+chef_version '>= 14'
 
 supports 'centos', '>= 7.0'
 supports 'redhat', '>= 7.0'

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -8,5 +8,5 @@ apt_repository 'google-chrome' do
 end.run_action(:add)
 
 package "google-chrome-#{node['chrome']['track']}" do
-  action :nothing
-end.run_action(node['chrome']['action'])
+  action node['chrome']['action'].to_sym
+end

--- a/recipes/dmg.rb
+++ b/recipes/dmg.rb
@@ -2,5 +2,5 @@ dmg_package 'Google Chrome' do
   dmg_name 'googlechrome'
   source node['chrome']['dmg_source']
   checksum node['chrome']['dmg_checksum']
-  action :nothing
-end.run_action(node['chrome']['action'])
+  action node['chrome']['action'].to_sym
+end

--- a/recipes/msi.rb
+++ b/recipes/msi.rb
@@ -1,6 +1,6 @@
 chrome64 = node['kernel']['machine'] == 'x86_64' && !node['chrome']['32bit_only']
 windows_package 'Google Chrome' do
   source chrome64 ? node['chrome']['msi_64'] : node['chrome']['msi']
-  action :nothing
+  action node['chrome']['action'].to_sym
   only_if { chrome_windows_version.nil? }
-end.run_action(node['chrome']['action'])
+end

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -6,5 +6,5 @@ yum_repository 'google-chrome' do
 end.run_action(:add)
 
 package "google-chrome-#{node['chrome']['track']}" do
-  action :nothing
-end.run_action(node['chrome']['action'])
+  action node['chrome']['action'].to_sym
+end


### PR DESCRIPTION
## Description
This change will allow actions to be set from node/environment/role json as well as from ruby attributes.
This also fixes the following error:
```
[2021-03-04T19:07:33+00:00] FATAL: RuntimeError: apt_package[google-chrome-stable] (chrome::apt line 10) had an error: RuntimeError: internal error - target_version_array in package provider does not understand this action
```